### PR TITLE
Fix when trying to fetch cities from API without any characters in input

### DIFF
--- a/src/app/utils/components/input-debounce.component.js
+++ b/src/app/utils/components/input-debounce.component.js
@@ -25,6 +25,7 @@ export class InputDebounceComponent implements OnInit {
   ngOnInit() {
     const eventStream = Observable.fromEvent(this.elementRef.nativeElement, 'keyup')
       .map(() => this.inputValue)
+      .filter(() => this.inputValue.length > 2)
       .debounceTime(this.delay)
       .distinctUntilChanged();
 


### PR DESCRIPTION
Fix when trying to fetch cities from API without any characters in input
Filter the requests to consider that no cities names are shorter than 3 chars
