### PR TITLE
Feature/slideout menu implementation

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -9,6 +9,7 @@ const process = require('process');
 const JS_FILES = ['src/**/*.js'];
 const CSS_FILES = ['src/**/*.scss'];
 const HTML_FILES = ['src/**/*.html'];
+const TERGET_VENDOR_FILES = 'dist/vendors';
 const TARGET = 'dist';
 
 const conf = require('./src/middleware/conf')();
@@ -24,6 +25,10 @@ const VENDOR_FILES = [
     'angular2/bundles/router.dev.js'
 ].map((file) => 'node_modules/' + file);
 
+const VENDOR_FILES_UNCHANGED = [
+    'slideout/dist/slideout.js'
+].map((file) => 'node_modules/' + file);
+
 gulp.task('app-html', () => {
     return gulp.src(HTML_FILES)
         .pipe(gulp.dest(TARGET));
@@ -32,7 +37,12 @@ gulp.task('app-html', () => {
 gulp.task('vendor-js', () => {
     return gulp.src(VENDOR_FILES)
         .pipe($.concatUtil('vendor.js'))
-        .pipe(gulp.dest(TARGET));
+        .pipe(gulp.dest(TERGET_VENDOR_FILES));
+});
+
+gulp.task('vendor-unchanged-js', () => {
+    return gulp.src(VENDOR_FILES_UNCHANGED)
+      .pipe(gulp.dest(TERGET_VENDOR_FILES));
 });
 
 gulp.task('app-js', () => {
@@ -80,4 +90,4 @@ gulp.task('watch', ['browser-sync'], () => {
     gulp.watch(JS_FILES, ['eslint-app-js', browserSync.reload]);
 });
 
-gulp.task('default', $.sequence('eslint-app-js', 'app-html', 'vendor-js', 'app-js', 'app-css'));
+gulp.task('default', $.sequence('eslint-app-js', 'app-html', 'vendor-js', 'vendor-unchanged-js', 'app-js', 'app-css'));

--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -26,7 +26,8 @@ const VENDOR_FILES = [
 ].map((file) => 'node_modules/' + file);
 
 const VENDOR_FILES_UNCHANGED = [
-    'slideout/dist/slideout.js'
+    'slideout/dist/slideout.js',
+    'lodash/lodash.js'
 ].map((file) => 'node_modules/' + file);
 
 gulp.task('app-html', () => {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "reflect-metadata": "0.1.2",
     "rxjs": "5.0.0-beta.0",
     "zone.js": "0.5.10",
+    "slideout": "^0.1.11",
     "babel-eslint": "^4.1.6",
     "babel-plugin-angular2-annotations": "^5.0.0",
     "babel-plugin-transform-class-properties": "^6.4.0",

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,19 +1,21 @@
-<nav id="slideout-menu" class="slideout__menu slideout__menu--background">
-    <header>
-        <h2 class="slideout__menu__title">Menu</h2>
-    </header>
-    <ul>
-        <li class="slideout__menu__item" [routerLink]="['Dashboard']">Dashboard</li>
-        <li class="slideout__menu__item" [routerLink]="['Dashboard']">Week forecast</li>
-        <li class="slideout__menu__item" [routerLink]="['Dashboard']">Locations</li>
-        <li class="slideout__menu__item" [routerLink]="['Dashboard']">Settings</li>
-    </ul>
-</nav>
+<slideout>
+    <div *slideoutItem="'menu'" class="slideout__menu slideout__menu--background">
+        <header>
+            <h2 class="slideout__menu__title">Menu</h2>
+        </header>
+        <ul>
+            <li class="slideout__menu__item" [routerLink]="['Dashboard']">Dashboard</li>
+            <li class="slideout__menu__item" [routerLink]="['Dashboard']">Week forecast</li>
+            <li class="slideout__menu__item" [routerLink]="['Dashboard']">Locations</li>
+            <li class="slideout__menu__item" [routerLink]="['Dashboard']">Settings</li>
+        </ul>
+    </div>
 
-<main id="slideout-content" class="slideout__content slideout__content--background">
-    <header>
-        <button (click)="toggleMenu()" class="toggle-button">☰</button>
-        <h1 class="title">Weather</h1>
-    </header>
-    <router-outlet></router-outlet>
-</main>
+    <div *slideoutItem="'content'" class="slideout__content slideout__content--background">
+        <header>
+            <button (click)="toggleMenu()" class="toggle-button">☰</button>
+            <h1 class="title">Weather</h1>
+        </header>
+        <router-outlet></router-outlet>
+    </div>
+</slideout>

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,0 +1,19 @@
+<nav id="slideout-menu" class="slideout__menu slideout__menu--background">
+    <header>
+        <h2 class="slideout__menu__title">Menu</h2>
+    </header>
+    <ul>
+        <li class="slideout__menu__item" [routerLink]="['Dashboard']">Dashboard</li>
+        <li class="slideout__menu__item" [routerLink]="['Dashboard']">Week forecast</li>
+        <li class="slideout__menu__item" [routerLink]="['Dashboard']">Locations</li>
+        <li class="slideout__menu__item" [routerLink]="['Dashboard']">Settings</li>
+    </ul>
+</nav>
+
+<main id="slideout-content" class="slideout__content slideout__content--background">
+    <header>
+        <button (click)="toggleMenu()" class="toggle-button">☰</button>
+        <h1 class="title">Weather</h1>
+    </header>
+    <router-outlet></router-outlet>
+</main>

--- a/src/app/app.component.js
+++ b/src/app/app.component.js
@@ -1,16 +1,16 @@
-import { Component, OnInit } from 'angular2/core';
+import { Component } from 'angular2/core';
 import { RouteConfig, ROUTER_DIRECTIVES } from 'angular2/router';
 
-import Slideout from '../vendors/slideout.js';
-
 import { DashboardComponent } from './dashboard/dashboard.component';
+import { SLIDEOUT_DIRECTIVES, SlideoutService } from './utils/directives/slideout.js';
+
 
 @Component({
   selector: 'weather-app',
   templateUrl: 'app/app.component.html',
-  directives: [ROUTER_DIRECTIVES]
+  directives: [ROUTER_DIRECTIVES, SLIDEOUT_DIRECTIVES],
+  providers: [SlideoutService]
 })
-
 @RouteConfig([
   {
     path: '/',
@@ -24,20 +24,18 @@ import { DashboardComponent } from './dashboard/dashboard.component';
     useAsDefault: true
   }
 ])
-export class AppComponent implements OnInit {
-  constructor() {
-  }
+export class AppComponent {
+  slideoutService;
 
-  ngOnInit() {
-    this.slideout = new Slideout({
-      panel: document.getElementById('slideout-content'),
-      menu: document.getElementById('slideout-menu'),
-      padding: 256,
-      tolerance: 70
-    });
+  static parameters = [SlideoutService];
+
+  constructor(slideoutService) {
+    this.slideoutService = slideoutService;
   }
 
   toggleMenu() {
-    this.slideout.toggle();
+    if (this.slideoutService.slideout) {
+      this.slideoutService.slideout.toggle();
+    }
   }
 }

--- a/src/app/app.component.js
+++ b/src/app/app.component.js
@@ -1,17 +1,13 @@
-import { Component } from 'angular2/core';
+import { Component, OnInit } from 'angular2/core';
 import { RouteConfig, ROUTER_DIRECTIVES } from 'angular2/router';
+
+import Slideout from '../vendors/slideout.js';
 
 import { DashboardComponent } from './dashboard/dashboard.component';
 
 @Component({
   selector: 'weather-app',
-  template: `
-    <h1 class="title">Weather</h1>
-    <nav>
-      <a [routerLink]="['Dashboard']">Dashboard</a>
-    </nav>
-    <router-outlet></router-outlet>
-  `,
+  templateUrl: 'app/app.component.html',
   directives: [ROUTER_DIRECTIVES]
 })
 
@@ -28,5 +24,20 @@ import { DashboardComponent } from './dashboard/dashboard.component';
     useAsDefault: true
   }
 ])
-export class AppComponent {
+export class AppComponent implements OnInit {
+  constructor() {
+  }
+
+  ngOnInit() {
+    this.slideout = new Slideout({
+      panel: document.getElementById('slideout-content'),
+      menu: document.getElementById('slideout-menu'),
+      padding: 256,
+      tolerance: 70
+    });
+  }
+
+  toggleMenu() {
+    this.slideout.toggle();
+  }
 }

--- a/src/app/utils/directives/slideout.js
+++ b/src/app/utils/directives/slideout.js
@@ -1,0 +1,114 @@
+import { Directive, Inject, ElementRef, TemplateRef, ViewContainerRef } from 'angular2/core';
+
+import Slideout from 'vendors/slideout.js';
+import * as _ from 'vendors/lodash.js';
+
+
+/**
+ * <slideout>
+ *    <div *slideoutItem="'menu'">Menu header + items</div>
+ *    <div *slideoutItem="'content'">Page content</div>
+ * </slideout>
+ */
+
+export class SlideoutService {
+  slideoutInstance;
+
+  constructor() {
+  }
+
+  set slideout(slideoutInstance) {
+    this.slideoutInstance = slideoutInstance;
+  }
+
+  get slideout() {
+    return this.slideoutInstance;
+  }
+}
+
+export class SlideoutDirective {
+  directives;
+  slideoutService;
+
+  static parameters = [
+    new Inject(SlideoutService)
+  ];
+
+  static annotations = [
+    new Directive({ selector: 'slideout' })
+  ];
+
+  constructor(slideoutService) {
+    this.directives = [];
+    this.slideoutService = slideoutService;
+  }
+
+  ngAfterContentInit() {
+    if (this.directives.length) {
+      const contentDirective = _.find(this.directives, { role: 'content' });
+      const menuDirective = _.find(this.directives, { role: 'menu' });
+
+      const contentContext = contentDirective && contentDirective.context;
+      const menuContext = menuDirective && menuDirective.context;
+
+      if (menuContext && contentContext) {
+        this.slideout = new Slideout({
+          panel: contentContext.elementRef.nativeElement.nextSibling,
+          menu: menuContext.elementRef.nativeElement.nextSibling,
+          padding: 256,
+          tolerance: 70
+        });
+
+        this.slideoutService.slideout = this.slideout;
+      } else {
+        this.slideoutService.slideout = null;
+        throw new Error(`Slideout items are not defined correctly.
+          Usage:
+          <slideout>
+            <div *slideoutItem="'menu'">Menu header + items</div>
+            <div *slideoutItem="'content'">Page content</div>
+          </slideout>
+          `);
+      }
+    }
+  }
+
+  registerComponent(component) {
+    this.directives.push(component);
+  }
+}
+
+export class SlideoutItemDirective {
+
+  static annotations = [
+    new Directive({
+      selector: '[slideoutItem]',
+      inputs: ['slideoutItem']
+    })
+  ];
+
+  static parameters = [
+    new Inject(ElementRef),
+    new Inject(TemplateRef),
+    new Inject(ViewContainerRef),
+    new Inject(SlideoutDirective)
+  ];
+
+  constructor(elementRef, templateRef, viewContainerRef, slideout) {
+    this.elementRef = elementRef;
+    this.templateRef = templateRef;
+    this.viewContainerRef = viewContainerRef;
+    this.slideout = slideout;
+  }
+
+  set slideoutItem(role) {
+    if (role) {
+      this.slideout.registerComponent({ role, context: this });
+      this.viewContainerRef.createEmbeddedView(this.templateRef);
+    } else {
+      this.viewContainerRef.clear();
+    }
+  }
+}
+
+export const SLIDEOUT_DIRECTIVES = [SlideoutDirective, SlideoutItemDirective];

--- a/src/index.html
+++ b/src/index.html
@@ -5,11 +5,12 @@
 
     <title>Weather app</title>
     <link rel="stylesheet" href="styles/app.css" type="text/css">
+    <link rel="stylesheet" href="styles/slideout-menu.css" type="text/css">
 </head>
 <body>
 <weather-app>Loading...</weather-app>
 </body>
-<script src="vendor.js"></script>
+<script src="vendors/vendor.js"></script>
 <script>
     System.config({
         packages: {

--- a/src/styles/app.scss
+++ b/src/styles/app.scss
@@ -1,3 +1,15 @@
+html, body {
+  width: 100%;
+  height: 100%;
+  margin: 0;
+  padding: 0
+}
+
+body, input[text], button {
+  color: #888;
+  font-family: Cambria, Georgia;
+}
+
 h1 {
   color: #369;
   font-family: Arial, Helvetica, sans-serif;
@@ -12,15 +24,6 @@ h2 {
 h3 {
   color: #444;
   font-weight: lighter;
-}
-
-body {
-  margin: 2em;
-}
-
-body, input[text], button {
-  color: #888;
-  font-family: Cambria, Georgia;
 }
 
 button {

--- a/src/styles/slideout-menu.scss
+++ b/src/styles/slideout-menu.scss
@@ -1,0 +1,54 @@
+.slideout-menu {
+  position: fixed;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  right: 0;
+  z-index: 0;
+  width: 256px;
+  overflow-y: auto;
+  overflow-scrolling: touch;
+  display: none;
+}
+
+.slideout-panel {
+  position: fixed;
+  top: 0px;
+  z-index: 1;
+  will-change: transform;
+}
+
+.slideout-open,
+.slideout-open body,
+.slideout-open .slideout-panel {
+  overflow: hidden;
+}
+
+.slideout-open .slideout-menu {
+  display: block;
+}
+
+.slideout__content {
+  height: 100%;
+  width: 100%;
+  margin: 0px;
+  padding: 1.5em;
+}
+
+.slideout__menu {
+  margin: 0px;
+  padding: 1em;
+}
+
+.slideout__menu--background {
+  background-color: rgb(29, 31, 32);
+  background-image: linear-gradient(145deg, rgb(29, 31, 32), rgb(64, 67, 72));
+}
+
+.slideout__content--background {
+  background-color: #FFFFFF;
+}
+
+.slideout__menu__title, .slideout__menu__item {
+  color: #ffffff;
+}


### PR DESCRIPTION
Encapsulate the slideout menu into a fancy angular 2 directive
- parent directive will register the items (roles)
- 2 directive with different roles (slideoutItem: menu and content)
- throw error in case of roles typo or an item is missing
- get rid of TS annotations and stuff for slideout directive
- export SLIDEOUT_DIRECTIVES which will be imported in app.component and added as directives to component
- export a SlideoutService which has an instance of the slideout menu to handle the toggle/open/close
